### PR TITLE
Update `atlasDownloader()` to use `galah` v2 syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Suggests:
     devtools,
     emld,
     formatR,
-    galah,
+    galah (>= 2.0.0),
     hexbin,
     htmltools,
     htmlwidgets,


### PR DESCRIPTION
Hi James!

I had a quick look at `atlasDownloader()` to make sure it was compatible with version 2.0 of `galah`; it helped me find some bugs on my end, so thanks for that! I've made some suggestions to ensure the new version doesn't break `BeeBDC`, while keeping everything as similar as possible. This code should be faster and deliver the same result as before. 

Up to you whether to include these changes, but I hope they're useful!

Cheers,
Martin

**Description of changes:**
- recommend `galah` version 2 or greater for this to work (in `Suggests` within `DESCRIPTION`)
- `galah_config()` now uses `directory` arg in place of `cache_directory`
- new `file` argument in `atlas_occurrences()`
- the above allows us to remove duplicated download step (also removes requirement for `rvest` and `httr` in this script)